### PR TITLE
Feature: Wallet Reset Function

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -94,6 +94,7 @@ export interface Helpers {
   getAddress: (provider: any) => Promise<string | any>
   getNetwork: (provider: any) => Promise<number | any>
   getBalance: (provider: any) => Promise<string | any>
+  resetWalletState: (disconnected?: boolean) => void
 }
 
 export interface WalletInterface {
@@ -108,7 +109,7 @@ export interface WalletInterface {
 
 export interface StateSyncer {
   get?: () => Promise<string | number | null>
-  onChange?: (updater: (val: number | string) => void) => void
+  onChange?: (updater: (val: number | string | undefined) => void) => void
 }
 
 export interface Wallet {
@@ -176,6 +177,7 @@ export interface ConfigOptions {
 export interface API {
   walletSelect: WalletSelectFunction
   walletCheck: WalletCheck
+  walletReset: () => void
   config: Config
   getState: GetState
 }
@@ -189,7 +191,7 @@ export interface WritableStore {
 export interface WalletInterfaceStore {
   subscribe: (subscriber: (store: any) => void) => () => void
   update: (
-    updater: (walletInterface: WalletInterface | null) => WalletInterface
+    updater: (walletInterface: WalletInterface | null) => WalletInterface | null
   ) => void
   set: (walletInterface: WalletInterface) => void | never
 }

--- a/src/modules/select/wallets/wallet-connect.ts
+++ b/src/modules/select/wallets/wallet-connect.ts
@@ -1,4 +1,8 @@
-import { WalletConnectOptions, WalletModule } from '../../../interfaces'
+import {
+  WalletConnectOptions,
+  WalletModule,
+  Helpers
+} from '../../../interfaces'
 
 import walletConnectIcon from '../wallet-icons/icon-wallet-connect'
 
@@ -9,7 +13,9 @@ function walletConnect(options: WalletConnectOptions): WalletModule {
     name: label || 'WalletConnect',
     svg: svg || walletConnectIcon,
     iconSrc,
-    wallet: async () => {
+    wallet: async (helpers: Helpers) => {
+      const { resetWalletState } = helpers
+
       const { default: WalletConnectProvider } = await import(
         '@walletconnect/web3-provider'
       )
@@ -19,6 +25,10 @@ function walletConnect(options: WalletConnectOptions): WalletModule {
       })
 
       provider.autoRefreshOnNetworkChange = false
+
+      provider.wc.on('disconnect', () => {
+        resetWalletState(true)
+      })
 
       return {
         provider,
@@ -40,7 +50,7 @@ function walletConnect(options: WalletConnectOptions): WalletModule {
             onChange: func => {
               provider
                 .send('eth_accounts')
-                .then((accounts: string[]) => func(accounts[0]))
+                .then((accounts: string[]) => accounts[0] && func(accounts[0]))
               provider.on('accountsChanged', (accounts: string[]) =>
                 func(accounts[0])
               )
@@ -65,7 +75,8 @@ function walletConnect(options: WalletConnectOptions): WalletModule {
                   'latest'
                 ])
               })
-          }
+          },
+          disconnect: () => provider.close()
         }
       }
     },

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -11,7 +11,8 @@ import {
   balance,
   wallet,
   state,
-  walletInterface
+  walletInterface,
+  resetWalletState
 } from './stores'
 
 import { getDeviceInfo } from './utilities'
@@ -84,7 +85,9 @@ function init(initialization: Initialization): API {
 
     if (subscriptions.network) {
       network.subscribe((networkId: number | null) => {
-        networkId && subscriptions.network(networkId)
+        if (networkId !== null) {
+          subscriptions.network(networkId)
+        }
       })
     }
 
@@ -98,7 +101,7 @@ function init(initialization: Initialization): API {
 
     if (subscriptions.wallet) {
       wallet.subscribe((wallet: Wallet) => {
-        wallet.provider && subscriptions.wallet(wallet)
+        wallet.provider !== null && subscriptions.wallet(wallet)
       })
     }
   }
@@ -144,6 +147,10 @@ function init(initialization: Initialization): API {
     })
   }
 
+  function walletReset(): void {
+    resetWalletState()
+  }
+
   function config(options: ConfigOptions): void {
     validateConfig(options)
     app.update((store: AppState) => ({ ...store, ...options }))
@@ -153,7 +160,7 @@ function init(initialization: Initialization): API {
     return get(state)
   }
 
-  return { walletSelect, walletCheck, config, getState }
+  return { walletSelect, walletCheck, walletReset, config, getState }
 }
 
 export default init

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -76,10 +76,11 @@ export const walletInterface: WalletInterfaceStore = createWalletInterfaceStore(
 
 walletInterface.subscribe((walletInterface: WalletInterface | null) => {
   if (walletInterface) {
+    const currentState = get(state)
     // reset state
-    balance.reset()
-    address.reset()
-    network.reset()
+    currentState.balance && balance.reset()
+    currentState.address && address.reset()
+    currentState.network && network.reset()
 
     // clear all current intervals if they exist
     currentSyncerIntervals.forEach(
@@ -94,6 +95,36 @@ walletInterface.subscribe((walletInterface: WalletInterface | null) => {
     ]
   }
 })
+
+export function resetWalletState(disconnected?: boolean) {
+  walletInterface.update((currentInterface: WalletInterface | null) => {
+    !disconnected &&
+      currentInterface &&
+      currentInterface.disconnect &&
+      currentInterface.disconnect()
+    return null
+  })
+
+  wallet.update(() => ({
+    name: undefined,
+    provider: undefined,
+    connect: undefined,
+    instance: undefined,
+    url: undefined,
+    loading: undefined
+  }))
+
+  balance.reset()
+  address.reset()
+  network.reset()
+
+  app.update(store => ({
+    ...store,
+    walletSelectInProgress: false,
+    walletSelectCompleted: false,
+    autoSelect: false
+  }))
+}
 
 function createWalletInterfaceStore(
   initialState: null | WalletInterface
@@ -164,7 +195,7 @@ function createWalletStateSliceStore(options: {
 function createBalanceStore(initialState: string | null): BalanceStore {
   let stateSyncer: StateSyncer
   let emitter: any
-  let emitterAddress: String
+  let emitterAddress: String | undefined
   let cancel: () => void = () => {}
 
   const { subscribe } = derived(
@@ -209,8 +240,11 @@ function createBalanceStore(initialState: string | null): BalanceStore {
         } else if (emitterAddress && !$address) {
           // no address, so set balance to undefined
           set && set(undefined)
+          emitterAddress = undefined
         }
       }
+
+      set(initialState)
     }
   )
 

--- a/src/views/WalletSelect.svelte
+++ b/src/views/WalletSelect.svelte
@@ -3,7 +3,7 @@
   import { get } from 'svelte/store'
   import { fade } from 'svelte/transition'
 
-  import { app, walletInterface, wallet } from '../stores'
+  import { app, walletInterface, wallet, resetWalletState } from '../stores'
 
   import Modal from '../components/Modal.svelte'
   import ModalHeader from '../components/ModalHeader.svelte'
@@ -116,7 +116,8 @@
       BigNumber,
       getNetwork,
       getAddress,
-      getBalance
+      getBalance,
+      resetWalletState
     })
 
     loadingWallet = undefined


### PR DESCRIPTION
This PR:

- Adds a `walletReset` function to the Onboard.js API. When called it will set all of the internal wallet state to the initial values when Onboard is initialized.

- Updates the WalletConnect module so that it correctly disconnects when either the user closes the session or if the `walletReset` function is called.

- Ensures that all state subscription callbacks are only called when the value changes and only once per change.

