### PR TITLE
Made disabling Authereum notifications optional

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -147,11 +147,16 @@ export interface TorusOptions {
   enableLogging?: boolean
 }
 
+export interface AuthereumOptions {
+  disableNotifications?: boolean
+}
+
 export interface WalletInitOptions
   extends CommonWalletOptions,
-    SdkWalletOptions,
-    WalletConnectOptions,
-    TorusOptions {
+  SdkWalletOptions,
+  WalletConnectOptions,
+  TorusOptions,
+  AuthereumOptions {
   walletName: string
 }
 

--- a/src/modules/select/wallets/authereum.ts
+++ b/src/modules/select/wallets/authereum.ts
@@ -1,9 +1,9 @@
 import authereumIcon from '../wallet-icons/icon-authereum.png'
 import { networkName } from '../../../utilities'
-import { WalletModule, CommonWalletOptions } from '../../../interfaces'
+import { WalletModule, AuthereumOptions, CommonWalletOptions } from '../../../interfaces'
 
-function authereum(options: CommonWalletOptions): WalletModule {
-  const { networkId, preferred, label, iconSrc, svg } = options
+function authereum(options: AuthereumOptions & CommonWalletOptions): WalletModule {
+  const { networkId, preferred, label, iconSrc, svg, disableNotifications } = options
 
   return {
     name: label || 'Authereum',
@@ -13,7 +13,7 @@ function authereum(options: CommonWalletOptions): WalletModule {
       const { default: Authereum } = await import('authereum')
       const instance = new Authereum({
         networkName: networkName(networkId),
-        disableNotifications: true
+        disableNotifications: disableNotifications // default: false
       })
 
       const provider = instance.getProvider()

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -529,6 +529,7 @@ export function validateWalletInit(
     enableLogging,
     loginMethod,
     showTorusButton,
+    disableNotifications,
     ...otherParams
   } = walletInit
 
@@ -631,6 +632,12 @@ export function validateWalletInit(
   validateType({
     name: 'walletInit.showTorusButton',
     value: showTorusButton,
+    type: 'boolean',
+    optional: true
+  })
+  validateType({
+    name: 'walletInit.disableNotifications',
+    value: disableNotifications,
     type: 'boolean',
     optional: true
   })


### PR DESCRIPTION
I've had some feedback wanting Authereum notifications when using Onboard. I've added an optional initialisation value to set this behaviour by copying those for Torus.

Note: This PR switches the default to allowing notifications. If you don't want this I can add a little logic to swap this. 