### PR TITLE
Add Metamask mobile support

### DIFF
--- a/src/modules/select/wallets/metamask.ts
+++ b/src/modules/select/wallets/metamask.ts
@@ -43,6 +43,7 @@ function metamask(
     link: 'https://metamask.io/',
     installMessage: extensionInstallMessage,
     desktop: true,
+    mobile: true,
     preferred
   }
 }


### PR DESCRIPTION
Currently Metamask Mobile is detected but can't be used due to it not being made available in the wallet select menu.

I've set the mobile flag to true so that it will appear.