### PR TITLE
fix: add "jsonrpc: '2.0'" to sendAsync methods

### DIFF
--- a/src/modules/select/wallets/portis.ts
+++ b/src/modules/select/wallets/portis.ts
@@ -51,6 +51,7 @@ function portis(options: SdkWalletOptions & CommonWalletOptions): WalletModule {
 
                   provider.sendAsync(
                     {
+                      jsonrpc: '2.0',
                       method: 'eth_getBalance',
                       params: [provider.address, 'latest'],
                       id: 1

--- a/src/modules/select/wallets/squarelink.ts
+++ b/src/modules/select/wallets/squarelink.ts
@@ -50,6 +50,7 @@ function squarelink(
 
                 provider.sendAsync(
                   {
+                    jsonrpc: '2.0',
                     method: 'eth_getBalance',
                     params: [instance.accounts[0], 'latest'],
                     id: 1

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -7,6 +7,7 @@ export function getNetwork(provider: any): Promise<number | any> {
   return new Promise((resolve, reject) => {
     provider.sendAsync(
       {
+        jsonrpc: '2.0',
         method: 'net_version',
         params: [],
         id: 42
@@ -24,6 +25,7 @@ export function getAddress(provider: any): Promise<string | any> {
   return new Promise((resolve, reject) => {
     provider.sendAsync(
       {
+        jsonrpc: '2.0',
         method: 'eth_accounts',
         params: [],
         id: 42
@@ -48,6 +50,7 @@ export function getBalance(provider: any): Promise<string | any> {
 
     provider.sendAsync(
       {
+        jsonrpc: '2.0',
         method: 'eth_getBalance',
         params: [currentAddress, 'latest'],
         id: 42


### PR DESCRIPTION
Having the jsonrpc version string is mandatory according to https://www.jsonrpc.org/specification.

Depending on the node the missing version string is problematic. Having Metamask connected to a local parity node resulted in onboard.js not detecting the network version. Also on the browser console you would see an error logged from Metamask:

```
code: -32600
message: "Unsupported JSON-RPC protocol version"
```

With this patch applied no error is logged in the console and the connection to the local Parity node is accepted. 
