### PR TITLE
Fix: Wallet Subscription

### DIFF
--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -130,9 +130,9 @@ function init(initialization: Initialization): API {
 
     if (subscriptions.wallet) {
       wallet.subscribe((wallet: Wallet) => {
-        wallet.provider !== null &&
-          subscriptions.wallet &&
-          subscriptions.wallet(wallet)
+        if (wallet.provider !== null) {
+          subscriptions.wallet && subscriptions.wallet(wallet)
+        }
       })
     }
   }

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -165,11 +165,11 @@ export function resetWalletState(options?: {
     // if walletName is the same as the current interface name then do a full reset (checking if to do a disconnect)
     if (currentInterface.name === walletName) {
       wallet.update(() => ({
-        name: null,
-        provider: null,
-        connect: null,
-        instance: null,
-        dashboard: null
+        name: undefined,
+        provider: undefined,
+        connect: undefined,
+        instance: undefined,
+        dashboard: undefined
       }))
 
       !disconnected &&


### PR DESCRIPTION
This PR makes changes to so that the `wallet` subscription is called if a wallet disconnects.