### PR TITLE
Add fallback fonts

### DIFF
--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -13,7 +13,7 @@
   /* .bn-onboard-modal */
   aside {
     display: flex;
-    font-family: 'Helvetica Neue';
+    font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
     justify-content: center;
     align-items: center;
     position: fixed;


### PR DESCRIPTION
As described in #412, if the font is missing, the default font is rendered, which looks pretty bad. 

I took the fallbacks from https://www.cssfontstack.com/Helvetica.