### PR TITLE
Fix: Ensure wallet enabled before making rpc requests

### DIFF
--- a/src/modules/select/wallets/opera-touch.ts
+++ b/src/modules/select/wallets/opera-touch.ts
@@ -13,17 +13,38 @@ function operaTouch(options: CommonWalletOptions): WalletModule {
     iconSrcSet: iconSrc || operaTouchIcon2x,
     svg,
     wallet: async (helpers: Helpers) => {
-      const { getProviderName, createModernProviderInterface } = helpers
+      const { getProviderName, getAddress, getBalance, getNetwork } = helpers
 
       const provider =
         (window as any).ethereum ||
         ((window as any).web3 && (window as any).web3.currentProvider)
 
+      let enabled = false
+
       return {
         provider,
         interface:
           provider && getProviderName(provider) === undefined
-            ? createModernProviderInterface(provider)
+            ? {
+                name: 'Opera Touch',
+                connect: () =>
+                  provider.enable().then((res: any) => {
+                    enabled = true
+                    return res
+                  }),
+                address: {
+                  get: () =>
+                    enabled ? getAddress(provider) : Promise.resolve(null)
+                },
+                network: {
+                  get: () =>
+                    enabled ? getNetwork(provider) : Promise.resolve(null)
+                },
+                balance: {
+                  get: () =>
+                    enabled ? getBalance(provider) : Promise.resolve(null)
+                }
+              }
             : null
       }
     },


### PR DESCRIPTION
Opera Touch now throws errors if a rpc request is made before the enabled permissions have been granted. This PR ensures that no rpc calls are made before the user has enabled access.