### PR TITLE
Handle and log provider engine error

### DIFF
--- a/src/modules/select/wallets/providerEngine.ts
+++ b/src/modules/select/wallets/providerEngine.ts
@@ -38,6 +38,8 @@ function createProvider(config: any) {
   provider.addProvider(rpcSubProvider)
   provider.start()
 
+  provider.on('error', console.error)
+
   return provider
 }
 


### PR DESCRIPTION
This PR handles and logs any errors that are thrown by the `web3-provider-engine`. This will hopefully fix #435 until we can move to a different provider implementation. The problem seemed to be that when the provider-engine threw an error, for some reason the dynamic import would fail, so it would try importing the js chunk again which would instantiate another provider connection, thus instantiating another block poll. This would get it stuck in a loop of errors.