### PR TITLE
Remove hard coded style on account select

### DIFF
--- a/src/modules/check/accounts.ts
+++ b/src/modules/check/accounts.ts
@@ -77,7 +77,7 @@ function accountSelect(
             `
           : `
           <div style="display: flex; align-items: center;">
-            <select id="account-select" onchange="window.accountSelect()" style="padding: 0.5rem;">
+            <select id="account-select" onchange="window.accountSelect();">
               ${accountsAndBalances.map(
                 (account: { balance: string; address: string }) =>
                   `<option>${account.address} --- ${

--- a/src/modules/check/accounts.ts
+++ b/src/modules/check/accounts.ts
@@ -77,7 +77,7 @@ function accountSelect(
             `
           : `
           <div style="display: flex; align-items: center;">
-            <select id="account-select" onchange="window.accountSelect();">
+            <select id="account-select" onchange="window.accountSelect();" class="bn-onboard-custom bn-onboard-account-select>
               ${accountsAndBalances.map(
                 (account: { balance: string; address: string }) =>
                   `<option>${account.address} --- ${

--- a/src/views/Onboard.svelte
+++ b/src/views/Onboard.svelte
@@ -38,6 +38,10 @@
     color: #91bced;
     border-color: #91bced;
   }
+
+  :global(.bn-onboard-wallet-check-section select) {
+    padding: 0.5rem;
+  }
 </style>
 
 {#if $app.walletSelectInProgress}

--- a/src/views/WalletCheck.svelte
+++ b/src/views/WalletCheck.svelte
@@ -334,7 +334,7 @@
     {/if}
 
     {#if activeModal.html}
-      <section>
+      <section class="bn-onboard-custom bn-onboard-wallet-check-section">
         {@html activeModal.html}
       </section>
     {/if}


### PR DESCRIPTION
This PR removes hard coded padding styles from the account select element to make it easily customizable.