### PR TITLE
Add missing quotation

### DIFF
--- a/src/modules/check/accounts.ts
+++ b/src/modules/check/accounts.ts
@@ -77,7 +77,7 @@ function accountSelect(
             `
           : `
           <div style="display: flex; align-items: center;">
-            <select id="account-select" onchange="window.accountSelect();" class="bn-onboard-custom bn-onboard-account-select>
+            <select id="account-select" onchange="window.accountSelect();" class="bn-onboard-custom bn-onboard-account-select">
               ${accountsAndBalances.map(
                 (account: { balance: string; address: string }) =>
                   `<option>${account.address} --- ${


### PR DESCRIPTION
- Add missing quotation in html string which was causing account select dropdown to render incorrectly
Fixes #454 