### PR TITLE
Adds eth-lattice-keyring to rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -68,6 +68,7 @@ export default {
     'trezor-connect',
     'ethereumjs-tx',
     'ethereumjs-util',
+    'eth-lattice-keyring',
     'hdkey',
     '@ledgerhq/hw-transport-u2f',
     '@ledgerhq/hw-app-eth',


### PR DESCRIPTION
The Lattice connector imports `eth-lattice-keyring` and uses it to build requests.

I noticed it was not included in this repo's rollup config and including it changes the`dist/cjs/lattice-xxxxxxxx.js` build:

```
            _context11.next = 20;
            return new Promise(function (resolve) {
              resolve(_interopNamespace(require('eth-lattice-keyring')));
            });
```

Previously, it was:

```
             _context11.next = 20;
            return new Promise(function (resolve) {
              resolve(require('./index-b08a3c95.js'));
            });
```

I'm assuming `eth-lattice-keyring` should be included here and I believe this is related to the following issue in our Yearn integration: https://github.com/iearn-finance/yearn-finance/issues/73, but this is not really my area of expertise so feedback here is welcome!

**UPDATE:** I tested these changes with a local copy of the Yearn app and it resolved the issue!