### PR TITLE
1.18.0-0.3.0: Enhancement - Send Onboard version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.18.0-0.2.0",
+  "version": "1.18.0-0.3.0",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,6 +1,7 @@
 import BlocknativeApi from 'bnc-sdk'
 import { get } from 'svelte/store'
 import { app } from './stores'
+import { version } from '../package.json'
 
 let blocknative: any
 
@@ -13,6 +14,7 @@ export function initializeBlocknative(
     dappId,
     networkId,
     name: 'Onboard',
+    appVersion: version,
     apiUrl
   })
   return blocknative
@@ -20,7 +22,7 @@ export function initializeBlocknative(
 
 export function getBlocknative(): any {
   if (!blocknative) {
-    const {dappId, networkId, apiUrl} = get(app)
+    const { dappId, networkId, apiUrl } = get(app)
     initializeBlocknative(dappId, networkId, apiUrl)
   }
   return blocknative


### PR DESCRIPTION
- Passes Onboard version to the SDK so that it can be sent to the server

Note: Tests currently fail due to the latest SDK not yet being used that accepts this parameter. I will increment the SDK version once it is released, but would like to do a final test on our staging environment first.