### PR TITLE
1.21.0-0.0.1: [fix] - isMobile Parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.21.0",
+  "version": "1.21.0-0.0.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -171,7 +171,6 @@ export interface CommonWalletOptions {
   label?: string
   iconSrc?: string
   svg?: string
-  isMobile: boolean
 }
 
 export interface SdkWalletOptions extends CommonWalletOptions {
@@ -366,7 +365,7 @@ export type AllWalletInitOptions = CommonWalletOptions &
   AuthereumOptions &
   LedgerOptions &
   WalletLinkOptions &
-  InjectedWithBalanceOptions & { networkId: number }
+  InjectedWithBalanceOptions & { networkId: number } & { isMobile: boolean }
 
 export interface WalletCheckCustomOptions {
   heading?: string

--- a/src/modules/select/index.ts
+++ b/src/modules/select/index.ts
@@ -1,4 +1,8 @@
-import { WalletModule, WalletInitOptions } from '../../interfaces'
+import {
+  WalletModule,
+  WalletInitOptions,
+  AllWalletInitOptions
+} from '../../interfaces'
 import { isWalletInit } from '../../validation'
 
 // wallets that qualify for default wallets need to have no
@@ -65,7 +69,7 @@ function select(
 function getModule(
   name: string
 ): Promise<{
-  default: (options: any) => WalletModule
+  default: (options: AllWalletInitOptions) => WalletModule
 }> {
   switch (name) {
     // Deprecated wallets
@@ -131,7 +135,7 @@ function getModule(
     case 'frame':
       return import('./wallets/frame')
     case 'ownbit':
-      return import('./wallets/ownbit')  
+      return import('./wallets/ownbit')
     default:
       throw new Error(`${name} is not a valid walletName.`)
   }

--- a/src/modules/select/wallets/metamask.ts
+++ b/src/modules/select/wallets/metamask.ts
@@ -4,7 +4,9 @@ import { WalletModule, Helpers, CommonWalletOptions } from '../../../interfaces'
 import metamaskIcon from '../wallet-icons/icon-metamask.png'
 import metamaskIcon2x from '../wallet-icons/icon-metamask@2x.png'
 
-function metamask(options: CommonWalletOptions): WalletModule {
+function metamask(
+  options: CommonWalletOptions & { isMobile: boolean }
+): WalletModule {
   const { preferred, label, iconSrc, svg, isMobile } = options
 
   return {


### PR DESCRIPTION
- Fixes TypeScript interface bug that was enforcing `isMobile` parameter as required for all wallet init objects.

Fixes #519 