### PR TITLE
Changed provider from `window.ethereum` to `window.eth`

### DIFF
--- a/src/modules/select/wallets/liquality.ts
+++ b/src/modules/select/wallets/liquality.ts
@@ -16,7 +16,7 @@ function liquality(options: CommonWalletOptions): WalletModule {
       const { getProviderName, createModernProviderInterface } = helpers
 
       const provider =
-        (window as any).ethereum ||
+        (window as any).eth ||
         ((window as any).web3 && (window as any).web3.currentProvider)
 
       return {


### PR DESCRIPTION
This PR will close #598 

Liquality provider is at `window.eth`.