### PR TITLE
1.29.0-0.5.6: [fix] keepkey eth sign transaction issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.29.0-0.5.5",
+  "version": "1.29.0-0.5.6",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/keepkey/index.ts
+++ b/src/modules/select/wallets/keepkey/index.ts
@@ -385,7 +385,7 @@ async function createKeepKeyProvider({
       gasPrice,
       gasLimit: gas,
       to,
-      value: value || '',
+      value: value || '0x0',
       data: data || '',
       chainId: networkId
     })


### PR DESCRIPTION
### Description

This PR fixes an issue that occurs when attempting to sign an Ethereum transaction with an `undefined` transaction value using a KeepKey wallet.

This issue happens because when `value` is `undefined` for a transaction (e.g. when interacting with a non-payable smart contract method), an empty string value is passed to the [@shapeshiftoss/hdwallet-keepkey](https://github.com/shapeshift/hdwallet/tree/master/packages/hdwallet-keepkey) `ethSignTx`, which expects a string in hex format prefixed with `0x`, as expressed in the [`ETHSignTx` interface](https://github.com/shapeshift/hdwallet/blob/c9baf29278bb13478f91c9a9d42abd588b468d65/packages/hdwallet-core/src/ethereum.ts#L43-L44) and demonstrated in the [integration tests](https://github.com/shapeshift/hdwallet/blob/master/integration/src/ethereum/ethereum.ts#L151).

This surfaces as a runtime error as seen below, triggered by a [@shapeshiftoss library failsafe](https://github.com/shapeshift/hdwallet/blob/master/packages/hdwallet-core/src/utils.ts#L44-L46) prior to executing the transaction.

<img width="972" alt="Screen Shot 2021-07-21 at 8 01 44 AM" src="https://user-images.githubusercontent.com/1393139/126492817-904a29b6-343a-492f-aa7a-b9a852f71dc9.png">

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
