### PR TITLE
1.29.0-0.5.8: [fix] keepkey message signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.29.0-0.5.7",
+  "version": "1.29.0-0.5.8",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/keepkey/index.ts
+++ b/src/modules/select/wallets/keepkey/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
+import * as ethUtil from 'ethereumjs-util'
 import {
   CommonWalletOptions,
   Helpers,
@@ -406,7 +407,7 @@ async function createKeepKeyProvider({
 
     const { signature } = await keepKeyWallet.ethSignMessage({
       addressNList,
-      message
+      message: ethUtil.toBuffer(message).toString("utf8")
     })
 
     return signature

--- a/src/modules/select/wallets/keepkey/index.ts
+++ b/src/modules/select/wallets/keepkey/index.ts
@@ -407,7 +407,7 @@ async function createKeepKeyProvider({
 
     const { signature } = await keepKeyWallet.ethSignMessage({
       addressNList,
-      message: ethUtil.toBuffer(message).toString("utf8")
+      message: ethUtil.toBuffer(message).toString('utf8')
     })
 
     return signature


### PR DESCRIPTION
### Description
`HookedWalletSubprovider`'s `signMessage` and `signPersonalMessage` expect `0x`-prefixed hex strings, while `hdwallet-keepkey` expects a UTF-8 string.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
