### PR TITLE
1.32.0-0.1.0: Switch network if RPC request is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.31.0-0.0.4",
+  "version": "1.31.0-0.1.4",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/check/network.ts
+++ b/src/modules/check/network.ts
@@ -22,7 +22,8 @@ function network(
       walletCheck,
       exit,
       stateSyncStatus,
-      stateStore
+      stateStore,
+      wallet
     } = stateAndHelpers
 
     if (network === null) {
@@ -40,7 +41,14 @@ function network(
         })
       }
     }
-
+    try {
+      await wallet?.provider?.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x' + appNetworkId?.toString(16) }]
+      })
+    } catch (e) {
+      // Could not switch networks so proceed as normal through the checks
+    }
     if (stateStore.network.get() != appNetworkId) {
       return {
         heading: heading || 'You Must Change Networks',


### PR DESCRIPTION
### Description
Onboard will try and execute the `wallet_switchEthereumChain` RPC request to switch networks for the user, if the RPC request isn't implemented by the wallet's provider it will fallback to displaying the Switch Network modal.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
