### PR TITLE
customNode on fortmatic wallet (polygon support)

### DIFF
--- a/src/modules/select/wallets/fortmatic.ts
+++ b/src/modules/select/wallets/fortmatic.ts
@@ -6,7 +6,7 @@ import fortmaticIcon from '../wallet-icons/icon-fortmatic'
 function fortmatic(
   options: SdkWalletOptions & { networkId: number }
 ): WalletModule {
-  const { apiKey, networkId, preferred, label, iconSrc, svg } = options
+  const { apiKey, networkId, preferred, label, iconSrc, svg, customNode } = options
 
   return {
     name: label || 'Fortmatic',
@@ -17,7 +17,11 @@ function fortmatic(
 
       const instance = new Fortmatic(
         apiKey,
-        networkId === 1 ? undefined : networkName(networkId)
+        customNode 
+          ? customNode
+          : networkId === 1 
+            ? undefined 
+            : networkName(networkId)
       )
 
       const provider = instance.getProvider()


### PR DESCRIPTION
Following the Fortmatic guide, could be awesome to pass along a customNode on the walletSelect config for the "formatic" wallet. The purpose of this is to handle other networks connections not officially supported by blocknative/onboard (e.g. Polygon (Matic)).

The idea was taken from https://docs.fortmatic.com/web3-integration/network-configuration#switch-network-to-custom-node.