### PR TITLE
1.33.0-0.2.1: [feature] Adds optional custom rpc url for formatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.33.0-0.1.1",
+  "version": "1.33.0-0.2.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/fortmatic.ts
+++ b/src/modules/select/wallets/fortmatic.ts
@@ -4,7 +4,7 @@ import { SdkWalletOptions, WalletModule, Helpers } from '../../../interfaces'
 import fortmaticIcon from '../wallet-icons/icon-fortmatic'
 
 function fortmatic(
-  options: SdkWalletOptions & { networkId: number, rpcUrl: string }
+  options: SdkWalletOptions & { networkId: number; rpcUrl: string }
 ): WalletModule {
   const { apiKey, rpcUrl, networkId, preferred, label, iconSrc, svg } = options
 

--- a/src/modules/select/wallets/fortmatic.ts
+++ b/src/modules/select/wallets/fortmatic.ts
@@ -4,9 +4,9 @@ import { SdkWalletOptions, WalletModule, Helpers } from '../../../interfaces'
 import fortmaticIcon from '../wallet-icons/icon-fortmatic'
 
 function fortmatic(
-  options: SdkWalletOptions & { networkId: number }
+  options: SdkWalletOptions & { networkId: number, rpcUrl: string }
 ): WalletModule {
-  const { apiKey, networkId, preferred, label, iconSrc, svg } = options
+  const { apiKey, rpcUrl, networkId, preferred, label, iconSrc, svg } = options
 
   return {
     name: label || 'Fortmatic',
@@ -17,7 +17,11 @@ function fortmatic(
 
       const instance = new Fortmatic(
         apiKey,
-        networkId === 1 ? undefined : networkName(networkId)
+        rpcUrl
+          ? { chainId: networkId, rpcUrl }
+          : networkId === 1
+          ? undefined
+          : networkName(networkId)
       )
 
       const provider = instance.getProvider()


### PR DESCRIPTION
### Description
Allows adding an `rpcUrl` to the Formatic wallet init option in order to use Formatic with custom chains such as Matic or Skale. See [Formatic docs](https://docs.fortmatic.com/web3-integration/network-configuration#switch-network-to-custom-node) for details.

Address #643

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
