### PR TITLE
1.33.0-0.3.3: [refactor] Lazy load ens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.33.0-0.3.2",
+  "version": "1.33.0-0.3.3",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,6 @@
 import bowser from 'bowser'
 import BigNumber from 'bignumber.js'
 import { get } from 'svelte/store'
-import ENS, { getEnsAddress } from '@ensdomains/ensjs'
 
 import { app } from './stores'
 import { WalletInterface, Ens } from './interfaces'
@@ -71,6 +70,11 @@ export function getAddress(provider: any): Promise<string | any> {
 export async function getEns(provider: any, address: string): Promise<Ens> {
   const { networkId } = get(app)
   try {
+    // There is an issue with ens and ts unable to find the
+    // declaration file for it even though it is present.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore - TS7016
+    const { default: ENS, getEnsAddress } = await import('@ensdomains/ensjs')
     const ens = new ENS({ provider, ensAddress: getEnsAddress(networkId) })
     const { name } = await ens.getName(address)
     const nameInterface = await ens.name(name)
@@ -84,6 +88,7 @@ export async function getEns(provider: any, address: string): Promise<Ens> {
     }
   } catch (e) {
     // Error getting ens
+    console.error(e)
     return {}
   }
 }


### PR DESCRIPTION
### Description
Reduce client side bundle size by dynamically importing the ENS library only if the developer wants to utilize that feature.

Partially addresses #650.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
