### PR TITLE
1.34.1-0.1.1: [update] WalletConnect v1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.34.1-0.1.0",
+  "version": "1.34.1-0.1.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@shapeshiftoss/hdwallet-keepkey": "^1.15.2",
     "@shapeshiftoss/hdwallet-keepkey-webusb": "^1.15.2",
     "@toruslabs/torus-embed": "^1.10.11",
-    "@walletconnect/web3-provider": "^1.6.0",
+    "@walletconnect/web3-provider": "^1.6.2",
     "authereum": "^0.1.12",
     "bignumber.js": "^9.0.0",
     "bnc-sdk": "^3.4.1",


### PR DESCRIPTION
This includes fixes for a few patches which is not urgent as the 1.6.0 upgrade but useful to include on onboard.js for developers as part of the next release cycle

**1.6.1**
- upgrade ws version
- fix mobile link filtering
- fix mobile link state update
- fix react-native connector prototype


**1.6.2**
- add direct link when a single desktop link is available
- fix re-subscription on WebSocket error
- fix deep link triggered on unsafeSend method


