### PR TITLE
1.34.1-0.1.0: [fix] network switch bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.34.1",
+  "version": "1.34.1-0.1.0",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/check/network.ts
+++ b/src/modules/check/network.ts
@@ -56,15 +56,16 @@ function network(
     }
     // Adds a check for WalletConnect since it hangs for unsupported rpc methods
     if (
-      !networkCheckRequested && stateStore.network.get() != appNetworkId &&
-        getProviderName(wallet?.provider) !== 'WalletConnect'
+      !networkCheckRequested &&
+      stateStore.network.get() != appNetworkId &&
+      getProviderName(wallet?.provider) !== 'WalletConnect'
     ) {
       try {
-          networkCheckRequested = true
-          await wallet?.provider?.request({
-            method: 'wallet_switchEthereumChain',
-            params: [{ chainId: '0x' + appNetworkId?.toString(16) }]
-          })
+        networkCheckRequested = true
+        await wallet?.provider?.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: '0x' + appNetworkId?.toString(16) }]
+        })
       } catch (e) {
         // Could not switch networks so proceed as normal through the checks
       }


### PR DESCRIPTION
### Description
Fixes bug where multiple Metamask switch network prompts were shown after user canceled the request.
Fixes #672

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
