### PR TITLE
1.34.2-0.0.3: Refactor the balance syncer to not start polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.34.2-0.0.2",
+  "version": "1.34.2-0.0.3",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -514,7 +514,7 @@ export interface WalletStateSliceStore {
   get: () => any
 }
 
-export interface BalanceStore extends WalletStateSliceStore{
+export interface BalanceStore extends WalletStateSliceStore {
   setStateSyncer: (stateSyncer: StateSyncer) => undefined
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -507,18 +507,15 @@ export interface WalletInterfaceStore {
 
 export interface WalletStateSliceStore {
   subscribe: (subscriber: (store: any) => void) => () => void
-  reset: () => void
   setStateSyncer: (
     stateSyncer: StateSyncer
   ) => { clear: () => void } | undefined
+  reset: () => void
   get: () => any
 }
 
-export interface BalanceStore {
-  subscribe: (subscriber: (store: any) => void) => () => void
+export interface BalanceStore extends WalletStateSliceStore{
   setStateSyncer: (stateSyncer: StateSyncer) => undefined
-  reset: () => void
-  get: () => any
 }
 
 export type Browser = {

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -290,7 +290,6 @@ function createWalletStateSliceStore(options: {
 
       if (get) {
         const interval: any = createInterval(() => {
-          console.log('polling for ', parameter)
           stateSyncStatus[parameter] = get()
             .then(newVal => {
               stateSyncStatus[parameter] = null

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -75,13 +75,28 @@ export function initializeStores() {
     initialState: null
   })
 
-  balance = get(app).dappId
-    ? createBalanceStore(null)
-    : createWalletStateSliceStore({
-        parameter: 'balance',
-        initialState: null,
-        intervalSetting: 1000
-      })
+  balance = get(
+    derived<WalletStateSliceStore, BalanceStore | WalletStateSliceStore>(
+      address,
+      $address => {
+        if (!$address) {
+          return {
+            subscribe: () => () => {},
+            setStateSyncer: (stateSyncer: StateSyncer) => undefined,
+            reset: () => {},
+            get: () => {}
+          }
+        }
+        return get(app).dappId
+          ? createBalanceStore(null)
+          : createWalletStateSliceStore({
+              parameter: 'balance',
+              initialState: null,
+              intervalSetting: 1000
+            })
+      }
+    )
+  )
 
   wallet = writable({
     name: null,
@@ -275,6 +290,7 @@ function createWalletStateSliceStore(options: {
 
       if (get) {
         const interval: any = createInterval(() => {
+          console.log('polling for ', parameter)
           stateSyncStatus[parameter] = get()
             .then(newVal => {
               stateSyncStatus[parameter] = null


### PR DESCRIPTION
### Description
Addresses #679

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
