### PR TITLE
1.34.2-0.0.6: [fix] BSC wallet balance polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.34.2-0.0.5",
+  "version": "1.34.2-0.0.6",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/binance-chain-wallet.ts
+++ b/src/modules/select/wallets/binance-chain-wallet.ts
@@ -18,9 +18,43 @@ function binanceChainWallet(
       // Ref: https://binance-wallet.gitbook.io/binance-chain-extension-wallet
       const provider = (window as any).BinanceChain
 
+      // The following code is necessary as when polling BSC wallet for a balance causes it to
+      // relaunch the login prompt indefinitely
+
+      let providerInterface = null
+      let address: string | number | null | undefined
+
+      if (provider) {
+        providerInterface = createModernProviderInterface(provider)
+
+        if (providerInterface.balance.get) {
+          if (providerInterface.address.get) {
+            // Save and override the address `get` method
+            // Enables us to save the address used below to determine when to get the balance
+            // We only want to get the balance after we get the address
+            const addressGet = providerInterface.address.get
+            providerInterface.address.get = async () => {
+              address = await addressGet()
+              return address
+            }
+          } else if (providerInterface.address.onChange) {
+            // Intercept the onChange event to save the address internally
+            providerInterface.address.onChange(updatedAddress => {
+              address = updatedAddress
+            })
+          }
+          // Save and override the balance `get` method -- only call the original method
+          // if we have an address from BSC
+          const balanceGet = providerInterface.balance.get
+          providerInterface.balance.get = () => {
+            return address ? balanceGet() : Promise.resolve(null)
+          }
+        }
+      }
+
       return {
         provider,
-        interface: provider && createModernProviderInterface(provider)
+        interface: providerInterface
       }
     },
     type: 'injected',

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -75,28 +75,13 @@ export function initializeStores() {
     initialState: null
   })
 
-  balance = get(
-    derived<WalletStateSliceStore, BalanceStore | WalletStateSliceStore>(
-      address,
-      $address => {
-        if (!$address) {
-          return {
-            subscribe: () => () => {},
-            setStateSyncer: (stateSyncer: StateSyncer) => undefined,
-            reset: () => {},
-            get: () => {}
-          }
-        }
-        return get(app).dappId
-          ? createBalanceStore(null)
-          : createWalletStateSliceStore({
-              parameter: 'balance',
-              initialState: null,
-              intervalSetting: 1000
-            })
-      }
-    )
-  )
+  balance = get(app).dappId
+    ? createBalanceStore(null)
+    : createWalletStateSliceStore({
+        parameter: 'balance',
+        initialState: null,
+        intervalSetting: 1000
+      })
 
   wallet = writable({
     name: null,


### PR DESCRIPTION
 ### Description
 * Reverts the original fix to the polling issue
 * Implements a fix isolated to BSC wallet module
 * Fix now won't allow call to get balance until an address is defined

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
