### PR TITLE
add blank wallet

### DIFF
--- a/src/modules/select/index.ts
+++ b/src/modules/select/index.ts
@@ -196,6 +196,8 @@ function getModule(name: string): Promise<{
       return import('./wallets/tp')
     case 'mewwallet':
       return import('./wallets/mewwallet')
+	case 'blankwallet':
+	  return import('./wallets/blankwallet')
     default:
       throw new Error(`${name} is not a valid walletName.`)
   }

--- a/src/modules/select/wallet-icons/icon-blankwallet.ts
+++ b/src/modules/select/wallet-icons/icon-blankwallet.ts
@@ -1,0 +1,7 @@
+const blankwalletIcon = `
+	<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M15 30C23.2843 30 30 23.2843 30 15C30 6.71573 23.2843 0 15 0C6.71573 0 0 6.71573 0 15C0 23.2843 6.71573 30 15 30ZM23.125 6.875H6.875V23.125H23.125V6.875Z" fill="currentColor"/>
+	</svg>
+`
+
+export default blankwalletIcon

--- a/src/modules/select/wallets/blankwallet.ts
+++ b/src/modules/select/wallets/blankwallet.ts
@@ -1,0 +1,45 @@
+import { extensionInstallMessage } from '../content'
+import { WalletModule, Helpers, CommonWalletOptions } from '../../../interfaces'
+
+import blankwalletIcon from '../wallet-icons/icon-blankwallet'
+
+function blankwallet(
+  options: CommonWalletOptions
+): WalletModule {
+  const { preferred, label, iconSrc, svg } = options
+
+  return {
+    name: label || 'Blank Wallet',
+    iconSrc,
+    svg: svg || blankwalletIcon,
+    wallet: async (helpers: Helpers) => {
+      const {
+        getProviderName,
+        createModernProviderInterface,
+        createLegacyProviderInterface
+      } = helpers
+
+      const provider =
+        (window as any).ethereum ||
+        ((window as any).web3 && (window as any).web3.currentProvider)
+
+      return {
+        provider,
+        interface:
+          provider && getProviderName(provider) === 'BlankWallet'
+            ? typeof provider.enable === 'function'
+              ? createModernProviderInterface(provider)
+              : createLegacyProviderInterface(provider)
+            : null
+      }
+    },
+    type: 'injected',
+    link: `https://www.goblank.io/`,
+    installMessage: extensionInstallMessage,
+    desktop: true,
+    mobile: false,
+    preferred
+  }
+}
+
+export default blankwallet

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -353,6 +353,10 @@ export function getProviderName(provider: any): string | undefined {
     return 'tp'
   }
 
+  if (provider.isBlank) {
+    return 'BlankWallet'
+  }
+
   // =====================================
   // When adding new wallet place above this metamask check as some providers
   // have an isMetaMask property in addition to the wallet's own `is[WalletName]`


### PR DESCRIPTION
Adding Support for Blank Wallet (goblank.io)

Blank is the most private, non-custodial Ethereum browser wallet.

Blank uses smart contracts that allow users to hide the amounts and origins of cryptocurrency held, in a decentralized and frictionless manner.

Each time you want to make a withdrawal, Blank will create a new wallet address for you with the amount of crypto that you requested, which originates from the smart contract where everyone’s funds are pooled.