### PR TITLE
1.35.0-0.0.4: [fix] Add chainId to WalletConnect constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.35.0-0.0.1",
+  "version": "1.35.0-0.0.2",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/wallet-connect.ts
+++ b/src/modules/select/wallets/wallet-connect.ts
@@ -54,6 +54,7 @@ function walletConnect(
       const provider = new WalletConnectProvider({
         infuraId: infuraKey,
         rpc,
+        chainId: networkId,
         bridge,
         pollingInterval
       })


### PR DESCRIPTION
### Description
WalletConnect wasn't getting passed the chainId causing it to default to 1.

Fixes #699 & #471

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks