### PR TITLE
Generic provider is injected always when using a custom list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.35.4",
+  "version": "1.35.4-0.0.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/index.ts
+++ b/src/modules/select/index.ts
@@ -75,7 +75,7 @@ function select(
       // This wallet is built into onboard so add the walletName and
       // the code below will load it as a wallet module
       wallets.unshift({ walletName: detectedWalletName })
-    } else if (detectedProviderName) {
+    } else if (!detectedWalletName && detectedProviderName) {
       // A provider has been detected but there is not a walletName therefore
       // this wallet is not built into onboard so add it as a generic injected wallet
       wallets.unshift({ walletName: 'detectedwallet' })


### PR DESCRIPTION
### Description
The generic provider is injected always when Metamask is added in the custom wallet list and also detected by onboard.js

I used the same approach that is already in the `if/else if` for the `defaultWalletNames` so they are using a similar code style

https://github.com/blocknative/onboard/blob/4751b5e3fad237b6933b8f2f356a8c0f201b4510/src/modules/select/index.ts#L124-L129

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
