### PR TITLE
1.36.0-0.1.1: [fix] remove providerName check for XDeFi Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.36.0-0.1.0",
+  "version": "1.36.0-0.1.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/xdefi.ts
+++ b/src/modules/select/wallets/xdefi.ts
@@ -13,22 +13,18 @@ function xdefi(options: CommonWalletOptions): WalletModule {
     iconSrcSet: iconSrc || xdefiIcon2x,
     svg,
     wallet: async (helpers: Helpers) => {
-      const {
-        getProviderName,
-        createModernProviderInterface,
-        createLegacyProviderInterface
-      } = helpers
+      const { createModernProviderInterface, createLegacyProviderInterface } =
+        helpers
 
       const provider = (window as any).xfi && (window as any).xfi.ethereum
 
       return {
         provider,
-        interface:
-          provider && getProviderName(provider) === 'XDEFI'
-            ? typeof provider.enable === 'function'
-              ? createModernProviderInterface(provider)
-              : createLegacyProviderInterface(provider)
-            : null
+        interface: provider
+          ? typeof provider.enable === 'function'
+            ? createModernProviderInterface(provider)
+            : createLegacyProviderInterface(provider)
+          : null
       }
     },
     type: 'injected',


### PR DESCRIPTION
### Description
Fix to allow onboardJS to connect to XDeFi Wallet if clicked on the 'XDeFi Wallet' option, as currently it recognizes it as MM and doesn't allow the user to connect to it.

Tested it on the onboardJS react-demo-app 
### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
