### PR TITLE
[coinbase wallet] use window.ethereum provider if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/coinbase.ts
+++ b/src/modules/select/wallets/coinbase.ts
@@ -13,7 +13,8 @@ function coinbase(options: CommonWalletOptions): WalletModule {
     wallet: async (helpers: Helpers) => {
       const { getProviderName, createLegacyProviderInterface } = helpers
       const provider =
-        (window as any).web3 && (window as any).web3.currentProvider
+        (window as any).ethereum ||
+        ((window as any).web3 && (window as any).web3.currentProvider)
 
       return {
         provider,


### PR DESCRIPTION
### Description
Update coinbase injected wallet to use `window.ethereum` provider if available.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
