### PR TITLE
resolve D'CENT wallet connection error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.37.1",
+  "version": "1.37.1-0.0.2",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/index.ts
+++ b/src/modules/select/index.ts
@@ -46,6 +46,8 @@ const providerNameToWalletName = (providerName: string) =>
     ? providerName
     : providerName === 'WalletConnect'
     ? 'walletConnect'
+    : providerName === `D'CENT`
+    ? 'dcent'
     : providerName.toLocaleLowerCase()
 
 function select(


### PR DESCRIPTION
### Description
<!-- Add a description of the fix or feature here -->
D'CENT provider name and wallet name is different.
So, I selected D'CENT wallet in mobile, `d'cent is not a valid walletName.` Error occured.

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
