### PR TITLE
1.37.0-0.0.3 : [enhancement] - Update to PR checklist for fork merges to run yarn with nove v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.37.0-0.0.2",
+  "version": "1.37.0-0.0.3",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,4 +5,4 @@
 - [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
 - [ ] The box that allows repo maintainers to update this PR is checked
 - [ ] I tested locally to make sure this feature/fix works
-- [ ] This PR passes the Circle CI checks
+- [ ] This PR passes the Circle CI checks (if **merging a fork** run `yarn` with node version 12.22.7 to ensure no errors)


### PR DESCRIPTION
### Description
Update PR checklist for PRs merging forks

### Checklist
- [ x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x ] The box that allows repo maintainers to update this PR is checked
- [ x] I tested locally to make sure this feature/fix works
- [x ] This PR passes the Circle CI checks
