### PR TITLE
More notes in Readme and  trezor connect package update

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -415,7 +415,7 @@ module.exports = {
 
 [CRACO](https://www.npmjs.com/package/@craco/craco) provides an easy way to override webpack config which is obfuscated in Creat React App built applications.
 
-The above webpack 5 example can be used in this case.
+The above webpack 5 example can be used in the `craco.config.js` file at the root level in this case.
 
 **Note:** currently still facing some challenges building with CRA and CRACO for hardware wallets
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -375,11 +375,11 @@ Many of the wallet modules require dependencies that are not normally included i
 
 Everything should just work since the node builtins are automatically bundled in v4
 
-### Webpack 5
+### Webpack 5 
 
 You'll need to add some dev dependencies with the following command:
 
-`npm -i --save-dev assert buffer crypto-browserify stream-http https-browserify os-browserify process stream-browserify util`
+`npm i --save-dev assert buffer crypto-browserify stream-http https-browserify os-browserify process stream-browserify util`
 
 Then add the following to your `webpack.config.js` file:
 
@@ -410,6 +410,14 @@ module.exports = {
   ]
 }
 ```
+
+#### If using create-react-app 
+
+[CRACO](https://www.npmjs.com/package/@craco/craco) provides an easy way to override webpack config which is obfuscated in Creat React App built applications.
+
+The above webpack 5 example can be used in this case.
+
+**Note:** currently still facing some challenges building with CRA and CRACO for hardware wallets
 
 ### SvelteKit
 

--- a/packages/keepkey/package.json
+++ b/packages/keepkey/package.json
@@ -10,6 +10,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",

--- a/packages/trezor/package.json
+++ b/packages/trezor/package.json
@@ -26,6 +26,6 @@
     "buffer": "^6.0.3",
     "ethereumjs-util": "^7.1.3",
     "tiny-secp256k1": "^2.1.2",
-    "trezor-connect": "^8.2.4"
+    "trezor-connect": "^8.2.6"
   }
 }


### PR DESCRIPTION
### Description

- More notes in Readme around Create React App usage with webpack  
- Trezor connect package update
- Enforcement of Node >=v16 for Keepkey module

