### PR TITLE
fix: wallet select error when no provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.37.3-0.0.2",
+  "version": "1.37.3-0.0.3",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/detectedwallet.ts
+++ b/src/modules/select/wallets/detectedwallet.ts
@@ -11,7 +11,7 @@ function injected(options: CommonWalletOptions): WalletModule {
 
   const name =
     label ||
-    Object.keys(provider)
+    Object.keys(provider || {})
       .find(
         key =>
           key.startsWith('is') &&


### PR DESCRIPTION
### Description
This should fix errors when doing walletSelect in browsers without provider (window.ethereum or window.web3)

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks (if **merging a fork** run `yarn` with node version 12.22.7 to ensure no errors)
