### PR TITLE
1.38.1-0.0.4 : [fix] - 1inch wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.38.1",
+  "version": "1.38.1-0.0.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/1inch.ts
+++ b/src/modules/select/wallets/1inch.ts
@@ -16,7 +16,8 @@ function oneInchWallet(options: CommonWalletOptions): WalletModule {
       const { createModernProviderInterface, getProviderName } = helpers
       const windowAsAny = window as any
       const provider =
-        windowAsAny.ethereum
+        windowAsAny.ethereum ||
+        (windowAsAny.web3 && windowAsAny.web3.currentProvider)
 
       return {
         provider,

--- a/src/modules/select/wallets/1inch.ts
+++ b/src/modules/select/wallets/1inch.ts
@@ -16,7 +16,7 @@ function oneInchWallet(options: CommonWalletOptions): WalletModule {
       const { createModernProviderInterface, getProviderName } = helpers
       const windowAsAny = window as any
       const provider =
-        windowAsAny || (windowAsAny.web3 && windowAsAny.web3.currentProvider)
+        windowAsAny.ethereum
 
       return {
         provider,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -369,10 +369,6 @@ export function getProviderName(provider: any): string | undefined {
     return '1inch'
   }
 
-  if (provider.isOneInchIOSWallet) {
-    return '1inch'
-  }
-
   // =====================================
   // When adding new wallet place above this metamask check as some providers
   // have an isMetaMask property in addition to the wallet's own `is[WalletName]`


### PR DESCRIPTION
### Description
There was an issue with how the 1inch wallet connected to the injected provider. This has been resolved

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks (if **merging a fork** run `yarn` with node version 12.22.7 to ensure no errors)
