### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/docs/src/routes/docs/[...4]wallets/[...35]zeal/+page.md
+++ b/docs/src/routes/docs/[...4]wallets/[...35]zeal/+page.md
@@ -8,7 +8,7 @@ Wallet module for connecting Zeal to Web3 Onboard.
 
 See [Zeal](https://www.zeal.app/) for details.
 
-For any questions or issues related to integration with Zeal wallet do not hesitate to contact our builders via [hi@zeal.app](mailto:hi@zeal.app) OR ping us on X [@withzeal](https://twitter.com/withzeal)
+For any questions or issues related to integration with Zeal wallet do not hesitate to contact our builders via [hi@zeal.app](mailto:hi@zeal.app) OR ping us on X [@withzeal](https://x.com/withzeal)
 
 ## Install
 

--- a/packages/zeal/README.md
+++ b/packages/zeal/README.md
@@ -4,7 +4,7 @@
 
 See [Zeal](https://www.zeal.app/) for details.
 
-For any questions or issues related to integration with Zeal wallet do not hesitate to contact our builders via [hi@zeal.app](mailto:hi@zeal.app) OR ping us on twitter [@withzeal](https://twitter.com/withzeal)
+For any questions or issues related to integration with Zeal wallet do not hesitate to contact our builders via [hi@zeal.app](mailto:hi@zeal.app) OR ping us on twitter [@withzeal](https://x.com/withzeal)
 
 ### Install
 


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.

