### PR TITLE
chore: remove blocknative links from header

### DIFF
--- a/docs/src/lib/components/Footer.svelte
+++ b/docs/src/lib/components/Footer.svelte
@@ -25,7 +25,7 @@
     --padding="2rem"
   >
     <Flexbox --direction="row" --gap="2rem" --padding="0">
-      <a class="icon-link" href="//github.com/blocknative/web3-onboard" target="_blank">
+      <a class="icon-link" href="//github.com/thirdweb-dev/web3-onboard" target="_blank">
         <GitHubIcon width={iconSize} height={iconSize} />
         <span class="sr-only">Github</span>
       </a>

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -28,7 +28,6 @@
       { title: 'Documentation', slug: '/docs', match: /\/docs/ },
       { title: 'Examples', slug: '/examples', match: /\/examples/ },
       { title: 'FAQ', slug: '/faq', match: /\/faq/ },
-      { title: 'Blog', slug: 'https://www.blocknative.com/blog/tag/web3-onboard' }
     ]
   }
 
@@ -71,8 +70,6 @@
     <div slot="navbar-right-alt">
       <div class="flex items-center">
         <ConnectWalletButton />
-        <SocialLink type="gitHub" href="//github.com/blocknative/web3-onboard" class="socialIcon" />
-        <SocialLink type="discord" href="//discord.com/invite/KZaBVME" class="socialIcon" />
       </div>
     </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the GitHub link in the footer to direct to the new repository location.

* **Refactor**
  * Removed the "Blog" link from the navigation menu.
  * Removed GitHub and Discord social media links from the navigation bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->