### PR TITLE
fix: use configured rpc for ENS lookups

### DIFF
--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -41,22 +41,28 @@ export const viemProviders: {
   [key: string]: PublicClient
 } = {}
 
+function getProviderCacheKey(chain: Chain): string {
+  return chain.rpcUrl || chain.publicRpcUrl || chain.id
+}
+
 async function getProvider(chain: Chain): Promise<PublicClient | null> {
   if (!chain) return null
 
-  if (!viemProviders[chain.rpcUrl as string]) {
+  const cacheKey = getProviderCacheKey(chain)
+
+  if (!viemProviders[cacheKey]) {
     const viemChain = await chainIdToViemENSImport(chain.id)
     if (!viemChain) return null
 
     const { createPublicClient, http } = await import('viem')
     const publicProvider = createPublicClient({
       chain: viemChain,
-      transport: http()
+      transport: http(chain.rpcUrl || chain.publicRpcUrl)
     })
-    viemProviders[chain.rpcUrl as string] = publicProvider as PublicClient
+    viemProviders[cacheKey] = publicProvider as PublicClient
   }
 
-  return viemProviders[chain.rpcUrl as string]
+  return viemProviders[cacheKey]
 }
 
 export function requestAccounts(


### PR DESCRIPTION
Fixes ENS lookups so the viem HTTP transport uses the RPC URL configured for the chain.

Previously `getProvider` created the public client with bare `http()`, so ENS resolution could fall back to viem's default RPC endpoint even when the chain config provided an RPC URL.

Changed:
- pass `chain.rpcUrl || chain.publicRpcUrl` into `http(...)`
- cache viem providers by the selected RPC URL, falling back to `publicRpcUrl` or `chain.id` when needed

Checked with:
- `npm exec --yes prettier@2.8.8 -- --check packages/core/src/provider.ts`
- static assertions that `getProvider` no longer uses bare `http()` and now passes the configured RPC URL

Closes #2356.